### PR TITLE
使配置的关键字支持正则表达式

### DIFF
--- a/utils/match.go
+++ b/utils/match.go
@@ -1,15 +1,22 @@
 package utils
 
 import (
+	"log"
+	"regexp"
 	"rss-reader/globals"
 	"strings"
 )
 
 func MatchStr(str string, callback func(string)) {
-	strFinal := strings.ToLower(strings.TrimSpace(str))
-	for _, v := range globals.MatchList {
-		v = strings.ToLower(strings.TrimSpace(v))
-		if strings.Contains(strFinal, v) {
+	strFinal := strings.TrimSpace(str)
+	for _, pattern := range globals.MatchList {
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			log.Printf("⚠️ Invalid regular expression: %s, error: %v", pattern, err)
+			continue
+		}
+
+		if re.MatchString(strFinal) {
 			callback(str)
 			return
 		}

--- a/utils/match.go
+++ b/utils/match.go
@@ -6,11 +6,12 @@ import (
 )
 
 func MatchStr(str string, callback func(string)) {
+	strFinal := strings.ToLower(strings.TrimSpace(str))
 	for _, v := range globals.MatchList {
-		strFinal := strings.ToLower(strings.TrimSpace(str))
 		v = strings.ToLower(strings.TrimSpace(v))
 		if strings.Contains(strFinal, v) {
 			callback(str)
+			return
 		}
 	}
 }

--- a/utils/match.go
+++ b/utils/match.go
@@ -10,6 +10,7 @@ import (
 func MatchStr(str string, callback func(string)) {
 	strFinal := strings.TrimSpace(str)
 	for _, pattern := range globals.MatchList {
+		pattern = "(?i)" + pattern
 		re, err := regexp.Compile(pattern)
 		if err != nil {
 			log.Printf("⚠️ Invalid regular expression: %s, error: %v", pattern, err)


### PR DESCRIPTION
感谢作者的开源项目，使用了一段时间了。
但一直有个痛点，就是关键字匹配不是很精确，特别是单字的情况，比如想关注二手交易，想匹配“出...”或“出一个...”或“【出】...”这种，如果只配置一个“出”作为关键则，会导致大量标题中间部分带有“出”字的，会错误推送过来。

该PR修改了推送的Match逻辑，允许用户配置正则表达式来筛选判断是否推送。

如下可以匹配，以“出”或“【出】”开头的标题：

```json
{
    "keywords": [
        "cc","cloudcone","rn","racknerd","咸鱼","4837","jpp","hk2p",
        "^【?出】?.*"
    ],
}
```

改动只是额外支持了配置正则表达式，不影响当前已有功能，即之前已配置的关键字都仍然有效。